### PR TITLE
1. 去掉sortMode的默认排序mode

### DIFF
--- a/elasticsearch-sql-core/src/main/java/io/github/iamazy/elasticsearch/dsl/sql/model/ElasticSqlParseResult.java
+++ b/elasticsearch-sql-core/src/main/java/io/github/iamazy/elasticsearch/dsl/sql/model/ElasticSqlParseResult.java
@@ -270,4 +270,25 @@ public class ElasticSqlParseResult {
         }
     }
 
+    public String toDsl() {
+        this.getSearchRequest();
+        if (searchRequest == null){
+            return null;
+        }
+        return searchRequest.source().toString();
+    }
+
+    public String toPrettyDsl() {
+        try {
+            this.getSearchRequest();
+            if (searchRequest == null){
+                return null;
+            }
+            Object o = CoreConstants.OBJECT_MAPPER.readValue(toDsl(searchRequest), Object.class);
+            return CoreConstants.OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(o);
+        } catch (IOException e) {
+            throw new RuntimeException("Elasticsearch Dsl解析出错!!!");
+        }
+    }
+
 }

--- a/elasticsearch-sql-core/src/main/java/io/github/iamazy/elasticsearch/dsl/sql/parser/QueryOrderByParser.java
+++ b/elasticsearch-sql-core/src/main/java/io/github/iamazy/elasticsearch/dsl/sql/parser/QueryOrderByParser.java
@@ -33,7 +33,7 @@ public class QueryOrderByParser implements QueryParser {
                         }else{
                             sortOrder=SortOrder.DESC;
                         }
-                        SortBuilder sortBuilder = SortBuilders.fieldSort(field).sortMode(SortMode.AVG).order(sortOrder);
+                        SortBuilder sortBuilder = SortBuilders.fieldSort(field).order(sortOrder);
                         dslContext.getParseResult().getOrderBy().add(sortBuilder);
                     }
                 }

--- a/elasticsearch-sql-core/src/main/java/io/github/iamazy/elasticsearch/dsl/sql/parser/query/exact/BinaryQueryParser.java
+++ b/elasticsearch-sql-core/src/main/java/io/github/iamazy/elasticsearch/dsl/sql/parser/query/exact/BinaryQueryParser.java
@@ -266,6 +266,9 @@ public class BinaryQueryParser extends AbstractExactQueryParser {
         if (expressionContext instanceof ElasticsearchParser.NameExprContext) {
             return true;
         }
+        if (expressionContext instanceof ElasticsearchParser.InContext) {
+            return true;
+        }
         return expressionContext instanceof ElasticsearchParser.JoinContext;
     }
 }

--- a/elasticsearch-sql-core/src/test/java/io/github/iamazy/elasticsearch/dsl/sql/FixedHistoryTest.java
+++ b/elasticsearch-sql-core/src/test/java/io/github/iamazy/elasticsearch/dsl/sql/FixedHistoryTest.java
@@ -1,0 +1,25 @@
+package io.github.iamazy.elasticsearch.dsl.sql;
+
+import org.junit.Test;
+
+public class FixedHistoryTest {
+
+    protected static ElasticSql2DslParser parser = new ElasticSql2DslParser();
+
+    @Test
+    public void fixedOn20211221() {
+        // 1. 去掉默认sortMode=avg ,默认为null
+        // @io/github/iamazy/elasticsearch/dsl/sql/parser/QueryOrderByParser.java:36
+        String fixDefaultSortMode = "select * from user order by id desc";
+        System.out.println(parser.parse(fixDefaultSortMode).toDsl());
+
+        // 2. 使得 and or 右侧 支持 in not in 等表达式
+        // @io/github/iamazy/elasticsearch/dsl/sql/parser/query/exact/BinaryQueryParser.java:138
+        String fixAndOrRightReg = "select * from user where id = 1 and ( name not in ('zs' ) or age < 18)";
+        System.out.println(parser.parse(fixAndOrRightReg).toDsl());
+
+        // 3. 添加无参toDsl
+        // @io.github.iamazy.elasticsearch.dsl.sql.model.ElasticSqlParseResult.toDsl()
+    }
+
+}


### PR DESCRIPTION
    @io/github/iamazy/elasticsearch/dsl/sql/parser/QueryOrderByParser.java:37
2. 使得Or 或 and 语句支持右表达式 使用in语句
   @io/github/iamazy/elasticsearch/dsl/sql/parser/query/exact/BinaryQueryParser.java:138
3. 添加无参toDsl, toPrettyDsl
   @io.github.iamazy.elasticsearch.dsl.sql.model.ElasticSqlParseResult.toDsl()