### PR TITLE
去除私有构造函数

### DIFF
--- a/elasticsearch-sql-jdbc/src/main/java/io/github/iamazy/elasticsearch/dsl/jdbc/ElasticDriver.java
+++ b/elasticsearch-sql-jdbc/src/main/java/io/github/iamazy/elasticsearch/dsl/jdbc/ElasticDriver.java
@@ -32,8 +32,6 @@ public class ElasticDriver implements Driver {
     private RestHighLevelClient restHighLevelClient;
     private ElasticClientProvider elasticClientProvider;
 
-    private ElasticDriver() {
-    }
 
     @Override
     public Connection connect(String url, Properties info) throws SQLException {


### PR DESCRIPTION
使用datasource连接时，会通过driverClass.newInstance()来初始化，如果构造方法私有会导致报错。